### PR TITLE
Fix datetime parsing issue in Gmail IMAP retrieval

### DIFF
--- a/modules/basic/email_imap_helper.py
+++ b/modules/basic/email_imap_helper.py
@@ -2,6 +2,7 @@ import imaplib
 import email
 from email.header import decode_header
 from datetime import datetime, timedelta
+from dateutil.parser import parse
 from html2text import HTML2Text
 from getpass import getpass
 import re
@@ -83,9 +84,9 @@ class EmailFetcher:
         subject = decode_header(email_message['Subject'])[0]
         decoded_subject = subject[0].decode(subject[1]) if subject[1] else subject[0]
 
-        # Get the 'Date' string, split at parentheses and take the first part
+        # Get the 'Date' string and parse it with dateutil
         date_str = email_message['Date'].split('(')[0].strip()
-        date = datetime.strptime(date_str, '%a, %d %b %Y %H:%M:%S %z').strftime('%d.%m.%Y %H:%M:%S')
+        date = parse(date_str).strftime('%d.%m.%Y %H:%M:%S')
 
         text_content = EmailFetcher.extract_text_content(email_message)
         summarized_content = EmailFetcher.summarize_content(text_content)


### PR DESCRIPTION
#### Summary:

This PR resolves the `ValueError` thrown when attempting to parse the email datetime string from Gmail's IMAP service. The problem arose due to a date string format mismatch. We now use the `dateutil` library to more robustly handle date parsing.

#### Changes:

- Replaced `datetime.strptime` with `dateutil.parser.parse` for date string parsing
- Removed hardcoded date format string, making the parsing more flexible

This PR closes #3.