### PR TITLE
Fix for cuDNN v9 recognition on Windows install_win.py

### DIFF
--- a/install_win.py
+++ b/install_win.py
@@ -117,7 +117,10 @@ def check_cudnn():
         r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\bin",
         r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\include",
         r"C:\tools\cuda\bin",
-        r"C:\tools\cuda\include"
+        r"C:\tools\cuda\include",
+        # Paths needed for cuDNN v9 to support CUDA 12, since the default .exe install filestructure has changed
+        r"C:\Program Files\NVIDIA\CUDNN\v9.2\bin\12.5",
+        r"C:\Program Files\NVIDIA\CUDNN\v9.2\include\12.5"
     ]
 
     cudnn_h_found = False
@@ -129,8 +132,8 @@ def check_cudnn():
             cudnn_h_found = True
         # Check for the existence of the cuDNN library file (dll)
         # The file name can vary based on the cuDNN version
-        # Here we are checking for version 7 as an example
-        if any(os.path.exists(os.path.join(path, f)) for f in ["cudnn64_7.dll", "cudnn64_8.dll"]):
+        # Here we are checking for version 7, 8, or 9 as an example
+        if any(os.path.exists(os.path.join(path, f)) for f in ["cudnn64_7.dll", "cudnn64_8.dll", "cudnn64_9.dll"]):
             cudnn_dll_found = True
 
     if cudnn_h_found and cudnn_dll_found:


### PR DESCRIPTION
Added the new default cuDNN installation location to the example paths for later versions of CUDA 12 (new lines 121-123) and added cudnn version 9 to the if-any statement on line 136 (formerly line 133 in the original). I made this after encountering an issue with them while installing with the latest CUDA and cuDNN on Windows. Anecdotally, manually editing path variables in the environment didn't help, only these changes in the code worked. (Sorry if any of this is confusing, I am not a programmer)